### PR TITLE
Added support for dependencies > 50MB via S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ GitHub Action to make zip deployment to AWS Lambda with requirements in a separa
 This action automatically installs requirements, zips and deploys the code including the dependencies as a separate layer.
 
 #### Python 3.8 is supported
+#### Also supports uploading dependecies greater than 50MB to layer
 
 ### Pre-requisites
 In order for the Action to have access to the code, you must use the `actions/checkout@master` job before it. 
@@ -32,6 +33,8 @@ Storing credentials as secret is stronly recommended.
     - Partial ARN - `123456789012:function:function-name`
 - `requirements_txt`
     The name/path for the `requirements.txt` file. Defaults to `requirements.txt`.
+- `s3_bucket`
+    Name of S3 bucket to upload dependencies.zip to
 
 ### Example Workflow
 ```yaml

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ GitHub Action to make zip deployment to AWS Lambda with requirements in a separa
 This action automatically installs requirements, zips and deploys the code including the dependencies as a separate layer.
 
 #### Python 3.8 is supported
-#### Also supports uploading dependecies greater than 50MB to layer
+#### Also supports uploading dependencies greater than 50MB to layer (via s3 buckets)
 
 ### Pre-requisites
 In order for the Action to have access to the code, you must use the `actions/checkout@master` job before it. 
 
 ### Structure
-- Lambda code should be `lambda_function.py`** unless you want to have a customized file name.
+- Lambda code should be `lambda_function.py` unless you want to have a customized file name.
 - **Dependencies must be stored in a `requirements.txt`**
 
 ### Environment variables
@@ -34,7 +34,7 @@ Storing credentials as secret is stronly recommended.
 - `requirements_txt`
     The name/path for the `requirements.txt` file. Defaults to `requirements.txt`.
 - `s3_bucket`
-    Name of S3 bucket to upload dependencies.zip to
+    Name of S3 bucket to upload dependencies.zip to (for dependencies over 50 MB)
 
 ### Example Workflow
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   lambda_function_name:
     description: The Lambda function name. Check the AWS docs/readme for examples.
     required: true
-   s3_bucket:
+  s3_bucket:
     description: s3 bucket to put deps in
     required: true
     default: ''

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: AWS Lambda Zip Deploy - Python
-author: quibitro
+author: qubitro
 description: Zip deploy to AWS Lambda with requirements in a separate layer.
 inputs:
   requirements_txt:

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,6 @@ inputs:
     required: true
   s3_bucket:
     description: s3 bucket to put deps in
-    required: true
     default: ''
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: AWS Lambda Zip Deploy - Python
-author: qubitro
+author: Qubitro
 description: Zip deploy to AWS Lambda with requirements in a separate layer.
 inputs:
   requirements_txt:

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
   lambda_function_name:
     description: The Lambda function name. Check the AWS docs/readme for examples.
     required: true
+   s3_bucket:
+    description: s3 bucket to put deps in
+    required: true
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -20,6 +24,7 @@ runs:
     - ${{ inputs.lambda_layer_arn }}
     - ${{ inputs.lambda_function_name }}
     - ${{ inputs.lambda_region }}
+    - ${{ inputs.s3_bucket }}
 branding:
   icon: 'cloud-lightning'
   color: 'white'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: AWS Lambda Zip Deploy - Python
-author: chadtolentino
+author: quibitro
 description: Zip deploy to AWS Lambda with requirements in a separate layer.
 inputs:
   requirements_txt:

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: true
   s3_bucket:
     description: s3 bucket to put deps in
-    default: ''
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: AWS Lambda Zip Deploy - Python
-author: Qubitro
+author: chadtolentino
 description: Zip deploy to AWS Lambda with requirements in a separate layer.
 inputs:
   requirements_txt:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ publish_dependencies_as_layer(){
 	#else
 	echo "uploading zip to s3"
 	aws s3 cp ./dependencies.zip "s3://${INPUT_S3_BUCKET}/"
-	local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --content "S3Bucket=${INPUT_S3_BUCKET},S3Key=dependencies.zip"
+	local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --content "S3Bucket=${INPUT_S3_BUCKET},S3Key=dependencies.zip")
 	#fi
 	LAYER_VERSION=$(jq '.Version' <<< "$result")
 	rm -rf python

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,14 +15,14 @@ install_zip_dependencies(){
 
 publish_dependencies_as_layer(){
 	echo "Publishing dependencies as a layer..."
-	if [[ -z ${INPUT_S3_BUCKET} ]]; then
-		echo "uploading zip directly"
-		local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --zip-file fileb://dependencies.zip)
-	else
-		echo "uploading zip to s3"
-		aws s3 cp ./dependencies.zip "s3://${INPUT_S3_BUCKET}/"
-		local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --content "S3Bucket=${INPUT_S3_BUCKET},S3Key=dependencies.zip"
-	fi
+	#if [[ -z ${INPUT_S3_BUCKET} ]]; then
+	#	echo "uploading zip directly"
+	#	local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --zip-file fileb://dependencies.zip)
+	#else
+	echo "uploading zip to s3"
+	aws s3 cp ./dependencies.zip "s3://${INPUT_S3_BUCKET}/"
+	local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --content "S3Bucket=${INPUT_S3_BUCKET},S3Key=dependencies.zip"
+	#fi
 	LAYER_VERSION=$(jq '.Version' <<< "$result")
 	rm -rf python
 	rm dependencies.zip

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,8 +16,10 @@ install_zip_dependencies(){
 publish_dependencies_as_layer(){
 	echo "Publishing dependencies as a layer..."
 	if [[ -z ${INPUT_S3_BUCKET} ]]; then
+		echo "uploading zip directly"
 		local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --zip-file fileb://dependencies.zip)
 	else
+		echo "uploading zip to s3"
 		aws s3 cp ./dependencies.zip "s3://${INPUT_S3_BUCKET}/"
 		local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --content "S3Bucket=${INPUT_S3_BUCKET},S3Key=dependencies.zip"
 	fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,14 +15,14 @@ install_zip_dependencies(){
 
 publish_dependencies_as_layer(){
 	echo "Publishing dependencies as a layer..."
-	#if [[ -z ${INPUT_S3_BUCKET} ]]; then
-	#	echo "uploading zip directly"
-	#	local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --zip-file fileb://dependencies.zip)
-	#else
-	echo "uploading zip to s3"
-	aws s3 cp ./dependencies.zip "s3://${INPUT_S3_BUCKET}/"
-	local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --content "S3Bucket=${INPUT_S3_BUCKET},S3Key=dependencies.zip")
-	#fi
+	if [[ -z ${INPUT_S3_BUCKET} ]]; then
+		echo "uploading zip directly"
+		local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --zip-file fileb://dependencies.zip)
+	else
+		echo "uploading zip to s3"
+		aws s3 cp ./dependencies.zip "s3://${INPUT_S3_BUCKET}/"
+		local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --content "S3Bucket=${INPUT_S3_BUCKET},S3Key=dependencies.zip")
+	fi
 	LAYER_VERSION=$(jq '.Version' <<< "$result")
 	rm -rf python
 	rm dependencies.zip

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,12 @@ install_zip_dependencies(){
 
 publish_dependencies_as_layer(){
 	echo "Publishing dependencies as a layer..."
-	local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --zip-file fileb://dependencies.zip)
+	if [[ -z ${INPUT_S3_BUCKET} ]]; then
+		local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --zip-file fileb://dependencies.zip)
+	else
+		aws s3 cp ./dependencies.zip "s3://${INPUT_S3_BUCKET}/"
+		local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --content "S3Bucket=${INPUT_S3_BUCKET},S3Key=dependencies.zip"
+	fi
 	LAYER_VERSION=$(jq '.Version' <<< "$result")
 	rm -rf python
 	rm dependencies.zip


### PR DESCRIPTION
Added an extra option to specify an s3 bucket to hold lambda layer dependencies greater than 50MB using an S3 bucket. Requires the bucket to be already created and available to access. If no bucket name specified, defaults to normal behavior.

Feel free to make changes if needed.